### PR TITLE
Update to public links for docs and feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ class TestSuite(unittest.TestCase):
         assert len(at.color_picker) == 2
 ```
 
-Read the fuller documentation on the preview [here](https://docs.google.com/document/d/1KTMUfUiLyM7vviug8FjyFIfm0oJB81s3RmigHrd2pbM/edit).
+Read the fuller documentation on the preview [here](https://docs.google.com/document/d/1Qscb-Ux8hEPo9hdoIjEw666wmzXO_u0JmpYo-4X6kSw/preview).
 
 See `test_app.py` for the tests and some further explanation.
 
@@ -87,5 +87,6 @@ and [recent CI runs including the test execution](https://github.com/AnOctopus/s
 
 ## 🎈 Let us know what you think! 🎈
 
-- Snowflake internal feedback: Leave comments in `#feat-streamlit-testing` on Slack
-- External feedback: *link to be added*
+- 👉 [Add your feedback in the forum](https://discuss.streamlit.io/t/feedback-wanted-for-streamlit-app-testing/52861)
+- ❄️ Snowflake internal feedback: Leave comments in `#feat-streamlit-app-testing` on Slack
+

--- a/docs/CODESPACES_WELCOME.md
+++ b/docs/CODESPACES_WELCOME.md
@@ -28,5 +28,5 @@ pytest
 Hopefully this is a helpful overview of the feature! A few resources to explore next:
 
 - View the [full README](./README.md) for this repo, including local and CI setup
-- [Detailed documentation]() - preview install instructions and API reference
-- [Add feedback here]()
+- [Detailed documentation](https://docs.google.com/document/d/1Qscb-Ux8hEPo9hdoIjEw666wmzXO_u0JmpYo-4X6kSw/preview) - preview install instructions and API reference
+- [Add feedback here](https://discuss.streamlit.io/t/feedback-wanted-for-streamlit-app-testing/52861)


### PR DESCRIPTION
Realized I had a couple non-public or missing links in the docs, and this repo has now been shared more publicly and have a few folks requesting access. Switching to the intended public links!